### PR TITLE
Add syn-antd to list of non-javascript libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ A list of starter projects and boilerplates built with Ant Design.
 A list of libraries that are written for non-JavaScript languages.
 
 - [Antizer](https://github.com/priornix/antizer) - Ant Design library for [ClojureScript](https://clojurescript.org/), an immutable, functional language that cross-compiles to JavaScript.
+- [syn-antd](https://gitlab.com/synqrinus/syn-antd) - Ant Design wrapper for [ClojureScript](https://clojurescript.org/) and [Reagent](https://github.com/reagent-project/reagent) using [shadow-cljs](http://shadow-cljs.org/) with tree-shaking support. As with other ClojureScript libraries, it cross-compiles to JavaScript.
 
 ## Electron
 


### PR DESCRIPTION
A clojurescript library that doesn't import the whole of antd, but allows for tree shaking and other optimizations via shadow-cljs optimized support.